### PR TITLE
use eval for resolving URLs. If a CSS File uses base64 encoded images in data tags, HTTP::CDN dies.

### DIFF
--- a/lib/Dancer/Plugin/CDN.pm
+++ b/lib/Dancer/Plugin/CDN.pm
@@ -19,7 +19,18 @@ register cdn_url => sub {
     my($path) = @_;
 
     $cdn ||= _init_cdn();
-    return $cdn->resolve($path);
+    
+    my $new_path;
+    eval {
+        $new_path = $cdn->resolve($path);
+    };
+    
+    if ($@) {
+        Dancer::Logger::warning("Could not process file '$path': " . $@);
+        return $path 
+    }
+    
+    return $new_path;
 };
 
 


### PR DESCRIPTION
HTTP::CDN fails.
